### PR TITLE
exporting coverage db to xml

### DIFF
--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -114,12 +114,14 @@ class CoverageDB(dict):
             #Common attributes
             attrib_dict['size'] = str(self[name_elem_full].size) 
             attrib_dict['coverage'] = str(self[name_elem_full].coverage)
-            attrib_dict['cover_percentage'] = str(round(self[name_elem_full].cover_percentage, 2))
+            attrib_dict['cover_percentage'] = str(round(
+                    self[name_elem_full].cover_percentage, 2))
             if (type(self[name_elem_full]) is not CoverItem):
                 attrib_dict['weight'] = str(self[name_elem_full].weight)
 
             #Create element: xml_db_dict[a.b.c] = et(a.b (parent), c (element))
-            xml_db_dict[name_elem_full] = et.SubElement(xml_db_dict[parent], name_elem, attrib=attrib_dict)
+            xml_db_dict[name_elem_full] = et.SubElement(xml_db_dict[parent],
+                name_elem, attrib=attrib_dict)
 
             #Additionally create bins for CoverCross and CoverPoint
             if bins and (type(self[name_elem_full]) is not CoverItem):
@@ -130,7 +132,9 @@ class CoverageDB(dict):
                     #attrib_dict['id'] = str(name_elem_full)
                     attrib_dict['bin_value'] = str(key)
                     attrib_dict['hits'] = str(value)
-                    xml_db_dict[name_elem_full+'.bin'+str(bin_count)] = et.SubElement(xml_db_dict[name_elem_full], 'bin'+str(bin_count), attrib=attrib_dict)
+                    xml_db_dict[name_elem_full+'.bin'+str(bin_count)] = (
+                        et.SubElement(xml_db_dict[name_elem_full],
+                        'bin'+str(bin_count), attrib=attrib_dict))
                     bin_count += 1
 
         for name in self:
@@ -139,11 +143,7 @@ class CoverageDB(dict):
             for index, name_elem in enumerate(name_list):
                 name_elem_full = '.'.join(name_list[:index+1])
                 if name_elem_full not in xml_db_dict.keys():
-                    if index == 0:
-                        parent = 'top'
-                    else:
-                        parent = '.'.join(name_list[:index])
-
+                    parent = 'top' if index == 0 else '.'.join(name_list[:index])
                     create_element(name_elem_full, parent, name_elem)
 
         et.ElementTree(top).write(xml_name+'.xml')

--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -107,16 +107,14 @@ class CoverageDB(dict):
             attrib_dict['size'] = str(self[name_elem_full].size) 
             attrib_dict['coverage'] = str(self[name_elem_full].coverage)
             attrib_dict['cover_percentage'] = str(round(self[name_elem_full].cover_percentage, 2))
-            if (type(self[name_elem_full]) == CoverPoint
-                or type(self[name_elem_full]) == CoverCross):
+            if (type(self[name_elem_full]) != CoverItem):
                 attrib_dict['weight'] = str(self[name_elem_full].weight)
 
             #Create element: xml_db_dict[a.b.c] = et(a.b (parent), c (element))
             xml_db_dict[name_elem_full] = et.SubElement(xml_db_dict[parent], name_elem, attrib=attrib_dict)
 
             #Additionally create bins for CoverCross and CoverPoint
-            if bins and (type(self[name_elem_full]) == CoverPoint
-                         or type(self[name_elem_full]) == CoverCross):
+            if bins and (type(self[name_elem_full]) != CoverItem):
                 bin_count = 0
                 #Database in format: key == bin_value, value == no_of_hits
                 for key, value in self[name_elem_full].detailed_coverage.items():

--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -100,11 +100,9 @@ class CoverageDB(dict):
                       )
 
     def export_to_xml(self, bins=True, xml_name='coverage'):
-        cov_db_tmp = []
         xml_db_dict = {}
         #Create xml root
-        top = et.Element('top')
-        xml_db_dict['top'] = top
+        xml_db_dict['top'] = et.Element('top')
 
         def create_element(name_elem_full, parent, name_elem):
             attrib_dict = {}
@@ -134,12 +132,7 @@ class CoverageDB(dict):
                     bin_count += 1
 
         for name in self:
-            cov_db_tmp.append(name)
-
-        #Create xml elements from coverage_db elements
-        while len(cov_db_tmp) > 0:
-            name_tmp = cov_db_tmp.pop(0)
-            name_list = name_tmp.split('.')
+            name_list = name.split('.')
             parent = ''
             for index, name_elem in enumerate(name_list):
                 name_elem_full = '.'.join(name_list[:index+1])

--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -49,11 +49,7 @@ import inspect
 import operator
 import itertools
 import warnings
-#accelerated C implementation is faster/lower mem footprint
-try:
-    import xml.etree.cElementTree as et
-except ImportError:
-    import xml.etree.ElementTree as et
+from xml.etree import ElementTree as et
 
 # global variable collecting coverage in a prefix tree (trie)
 class CoverageDB(dict):

--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -96,9 +96,17 @@ class CoverageDB(dict):
                       )
 
     def export_to_xml(self, bins=True, xml_name='coverage'):
+        """Export coverage_db to xml document.
+        
+        Args:
+            bins (bool): Option to omit bins in the xml
+            xml_name (str): Document name w/o .xml
+        
+        """
         xml_db_dict = {}
         #Create xml root
-        xml_db_dict['top'] = et.Element('top')
+        top = et.Element('top')
+        xml_db_dict['top'] = top
 
         def create_element(name_elem_full, parent, name_elem):
             attrib_dict = {}
@@ -107,14 +115,14 @@ class CoverageDB(dict):
             attrib_dict['size'] = str(self[name_elem_full].size) 
             attrib_dict['coverage'] = str(self[name_elem_full].coverage)
             attrib_dict['cover_percentage'] = str(round(self[name_elem_full].cover_percentage, 2))
-            if (type(self[name_elem_full]) != CoverItem):
+            if (type(self[name_elem_full]) is not CoverItem):
                 attrib_dict['weight'] = str(self[name_elem_full].weight)
 
             #Create element: xml_db_dict[a.b.c] = et(a.b (parent), c (element))
             xml_db_dict[name_elem_full] = et.SubElement(xml_db_dict[parent], name_elem, attrib=attrib_dict)
 
             #Additionally create bins for CoverCross and CoverPoint
-            if bins and (type(self[name_elem_full]) != CoverItem):
+            if bins and (type(self[name_elem_full]) is not CoverItem):
                 bin_count = 0
                 #Database in format: key == bin_value, value == no_of_hits
                 for key, value in self[name_elem_full].detailed_coverage.items():

--- a/tests/test_coverage/coverage_unittest.py
+++ b/tests/test_coverage/coverage_unittest.py
@@ -65,7 +65,7 @@ class TestCoverage(unittest.TestCase):
         for i in range(10):
             self.assertTrue(coverage.coverage_db["t1.c1"].detailed_coverage[i] == 1)
 
-        coverage.coverage_db.report_coverage(print, bins=False)
+        #coverage.coverage_db.report_coverage(print, bins=False)
 
     class FooBar():
         def __init__(self):
@@ -227,6 +227,21 @@ class TestCoverage(unittest.TestCase):
     #test xml export
     def test_xml(self):
         print("Running test_xml")
+        
+        #test CoverCheck
+        @coverage.CoverCheck(name = "t7.failed_check", 
+                             f_fail = lambda x : x == 0, 
+                             f_pass = lambda x : x > 500)
+        @coverage.CoverCheck(name = "t7.passing_check", 
+                             f_fail = lambda x : x > 100, 
+                             f_pass = lambda x : x < 50)
+        def sample(i):
+            pass
+        
+        for i in range(50):            
+            sample(i)
+            
+        coverage.coverage_db.report_coverage(print, bins=False)
         
         #Export coverage to XML, check if file exists
         filename = 'coverage_test'

--- a/tests/test_coverage/coverage_unittest.py
+++ b/tests/test_coverage/coverage_unittest.py
@@ -221,6 +221,11 @@ class TestCoverage(unittest.TestCase):
         self.assertTrue(cb1_fired[0])
         self.assertTrue(cb2_fired[0])
         self.assertTrue(cb3_fired[0])
+
+    #test xml export
+    def test_xml(self):
+        print("Running test_xml")
+        coverage.coverage_db.export_to_xml(xml_name='coverage_test')
         
 if __name__ == '__main__':
     import sys

--- a/tests/test_coverage/coverage_unittest.py
+++ b/tests/test_coverage/coverage_unittest.py
@@ -33,8 +33,6 @@ from cocotb_coverage import coverage
 
 import unittest
 import random
-import os.path
-from xml.etree import ElementTree as et
 
 class TestCoverage(unittest.TestCase):
 
@@ -226,6 +224,8 @@ class TestCoverage(unittest.TestCase):
 
     #test xml export
     def test_xml(self):
+        import os.path
+        from xml.etree import ElementTree as et
         print("Running test_xml")
         
         #test CoverCheck

--- a/tests/test_coverage/coverage_unittest.py
+++ b/tests/test_coverage/coverage_unittest.py
@@ -33,6 +33,7 @@ from cocotb_coverage import coverage
 
 import unittest
 import random
+import os.path
 
 class TestCoverage(unittest.TestCase):
 
@@ -226,6 +227,7 @@ class TestCoverage(unittest.TestCase):
     def test_xml(self):
         print("Running test_xml")
         coverage.coverage_db.export_to_xml(xml_name='coverage_test')
+        self.assertTrue(os.path.isfile('coverage_test.xml'))
         
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Added a method to export coverage db object to xml file. There is an option to omit bins in the xml as well as define the xml file name. Merging xmls are not possible yet.