### PR TITLE
Always close file descriptor

### DIFF
--- a/tests/test_coverage/coverage_test.py
+++ b/tests/test_coverage/coverage_test.py
@@ -271,11 +271,12 @@ def test_xml_export():
                 assert elem_parent in child_parent_dict[elem]
 
     # Check YML
-    yml_db = yaml.safe_load(open(yml_filename, 'r'))
-    for item in yml_db:
-        if isinstance(coverage.coverage_db[item], coverage.CoverPoint):
-            #assert if correct coverage levels
-            assert yml_db[item]['coverage'] == coverage.coverage_db[item].coverage
+    with open(yml_filename, 'r') as fp:
+        yml_db = yaml.safe_load(fp)
+        for item in yml_db:
+            if isinstance(coverage.coverage_db[item], coverage.CoverPoint):
+                #assert if correct coverage levels
+                assert yml_db[item]['coverage'] == coverage.coverage_db[item].coverage
 
     # check if yaml and coverage databases have equal size
     assert len(yml_db) == len(coverage.coverage_db) 


### PR DESCRIPTION
Running the test suite reports that a file descriptor isn't closed.

```
tests/test_coverage/coverage_test.py:274: ResourceWarning: unclosed file <_io.TextIOWrapper name='test_yaml_export_output.yml' mode='r' encoding='UTF-8'>
    yml_db = yaml.safe_load(open(yml_filename, 'r'))
```

Ensure the file is closed by using a context manager.