### PR TITLE
Testing: Only include test dependencies in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ whitelist_externals =
     make
 
 deps =
-    cocotb
     pytest
-    pyyaml
 
 commands =
     make -k -C tests


### PR DESCRIPTION
Tox honors the dependencies of cocotb-coverage that are specified in
setup.py. Only additional dependencies to run the tests need to be
specified in tox.ini.