### PR TITLE
Modernize codebase to use (and require) cocotb 1.5+

### DIFF
--- a/examples/fifo/tests/Makefile
+++ b/examples/fifo/tests/Makefile
@@ -6,5 +6,4 @@ VERILOG_SOURCES = $(PWD)/../hdl/fifo.v
 TOPLEVEL := fifo_mem
 MODULE   := test_fifo
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/pkt_switch/tests/Makefile
+++ b/examples/pkt_switch/tests/Makefile
@@ -6,5 +6,4 @@ VERILOG_SOURCES = $(PWD)/../hdl/pkt_switch.v
 TOPLEVEL := pkt_switch
 MODULE   := test_pkt_switch
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/pkt_switch/tests/test_pkt_switch.py
+++ b/examples/pkt_switch/tests/test_pkt_switch.py
@@ -36,8 +36,9 @@ transmitted correctly.
 
 import cocotb
 from cocotb.triggers import Timer, RisingEdge, ReadOnly
-from cocotb.drivers import BusDriver
-from cocotb.monitors import BusMonitor
+
+from cocotb_bus.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
 
 from cocotb_coverage.coverage import *
 from cocotb_coverage.crv import *

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author='Marek Cieplucha',
     author_email='',
     packages=find_packages(),
-    install_requires= ['cocotb', 'python-constraint', 'pyyaml'],
+    install_requires= ['cocotb ~= 1.5', 'python-constraint', 'pyyaml'],
     python_requires=">=3.3",
     platforms='any',
     classifiers=[

--- a/tests/test_coverage/Makefile
+++ b/tests/test_coverage/Makefile
@@ -10,5 +10,4 @@ TESTS_DIR = $(abspath $(dir $(abspath $(shell pwd))))
 
 VERILOG_SOURCES = $(TESTS_DIR)/sample_module.sv
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_crv/Makefile
+++ b/tests/test_crv/Makefile
@@ -10,5 +10,4 @@ TESTS_DIR = $(abspath $(dir $(abspath $(shell pwd))))
 
 VERILOG_SOURCES = $(TESTS_DIR)/sample_module.sv
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ deps =
     cocotb
     pytest
     pyyaml
+    cocotb-bus
+    numpy
 
 commands =
     make -k -C tests
+    make -C examples/fifo/tests
+    make -C examples/pkt_switch/tests


### PR DESCRIPTION
This PR contains three commits to update the codebase to use more of the features introduced with cocotb 1.5 and newer.

* Don't include Makefile.inc any more
* Use bus components from cocotb-bus

Finally, to ensure things continue to work:

* Test examples through tox (and in CI)