### PR TITLE
coverage.py: minor doc fix for coverage_section

### DIFF
--- a/cocotb_coverage/coverage.py
+++ b/cocotb_coverage/coverage.py
@@ -892,7 +892,7 @@ def coverage_section(*coverItems):
 
     Example:
 
-    >>> my_coverage = coverage.coverageSection(
+    >>> my_coverage = coverage.coverage_section(
     ...     coverage.CoverPoint("x", ...),
     ...     coverage.CoverPoint("y", ...),
     ...     coverage.CoverCross("z", ...),


### PR DESCRIPTION
Minor doc fix. Noticed the example was in camel case, where the function is actually underscore case.