### PR TITLE
Fix random seed to prevent random failures

### DIFF
--- a/tests/test_coverage/Makefile
+++ b/tests/test_coverage/Makefile
@@ -3,8 +3,9 @@
 #Just run it by:
 #python -m pytest
 
-MODULE = coverage_test_main
-TOPLEVEL := sample_module
+COCOTB_TEST_MODULES = coverage_test_main
+COCOTB_TOPLEVEL := sample_module
+export COCOTB_RANDOM_SEED := 0
 
 TESTS_DIR = $(abspath $(dir $(abspath $(shell pwd))))
 

--- a/tests/test_crv/Makefile
+++ b/tests/test_crv/Makefile
@@ -3,8 +3,9 @@
 #Just run it by:
 #python -m pytest
 
-MODULE = crv_test_main
-TOPLEVEL := sample_module
+COCOTB_TEST_MODULES = crv_test_main
+COCOTB_TOPLEVEL := sample_module
+export COCOTB_RANDOM_SEED = 0
 
 TESTS_DIR = $(abspath $(dir $(abspath $(shell pwd))))
 


### PR DESCRIPTION
I noticed the ecosystem test upstream randomly fails coverage so we fix the seed so the randomization is more consistent.